### PR TITLE
feat: standardize slash commands and sync app manifest for discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ This section documents each Slack command with purpose, example usage, and expec
 | `/project [name]` | Find OWASP project info | `/project zap` | BLT-Sammich only |
 | `/repo [tech]` | Find repos by technology | `/repo python` | BLT-Sammich only |
 | `/discover [term]` | Search all OWASP repos | `/discover security` | Main BLT only |
-| `/help [term]` | Show help menu | `/help` | BLT-Sammich only |
+| `/help` | Show bot help and command documentation | `/help` | BLT-Sammich only |
 
 
 ## 🧑‍💻 Local Development

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Searches and browses OWASP repositories.
 
 ### Plugins Architecture
 
-BLT-Sammich is built with a modular plugin system designed to run efficently at the edge:
+BLT-Sammich is built with a modular plugin system designed to run efficiently at the edge:
 
 1. **Contributors Plugin** (`src/sammich/plugins/contributors.py`)
    - Fetches GitHub data via REST API
@@ -106,7 +106,7 @@ BLT-Sammich is built with a modular plugin system designed to run efficently at 
 3. **Reminder Plugin** (`src/sammich/plugins/reminder.py`)
    - Parse natural language time expressions
    - Formats scheduled messages for channels
-   - *(Note: Currently being adapted from background tasks to Cloudflare Cron Triggers for the serverless environment)* 
+   - *(Note: Currently **disabled**; planned migration from background tasks to Cloudflare Cron Triggers)* 
 
 ### Data Files
 
@@ -118,7 +118,7 @@ BLT-Sammich is built with a modular plugin system designed to run efficently at 
 ### Tech Stack
 - **Edge Runtime:** Cloudflare Python Workers (Pyodide) - A zero-dependency, event-driven model that runs Python natively in the V8 engine
 - **Database:** Cloudflare D1 (Serverless SQLite)
-- **GitHub Integration:** Edge compatible REST requests
+- **GitHub Integration:** Edge-compatible REST requests
 - **Deployment & Testing:** Wrangler (`npx wrangler`) 
 
 ### How It Connects to Main BLT
@@ -148,99 +148,7 @@ BLT-Sammich is built with a modular plugin system designed to run efficently at 
 
 ## 🚀 Setup
 
-### Prerequisites
-- Python 3.10+
-- Poetry (for dependency management)
-- Slack workspace with admin access
-- GitHub account and token
-
-### 1. Clone the Repository
-```bash
-git clone https://github.com/OWASP-BLT/BLT-Sammich.git
-cd BLT-Sammich
-```
-
-### 2. Install Dependencies
-```bash
-poetry install
-```
-
-### 3. Create Slack App
-
-1. Go to [https://api.slack.com/apps](https://api.slack.com/apps)
-2. Click "Create New App" → "From scratch"
-3. Name your app (e.g., "BLT-Sammich Dev") and select your workspace
-
-### 4. Configure Slack App Permissions
-
-Navigate to **OAuth & Permissions** and add these Bot Token Scopes:
-- `commands` - Create and handle slash commands
-- `chat:write` - Send messages
-- `users:read` - Read user information
-- `channels:read` - View channels
-- `groups:read` - View private channels
-- `im:read` - View direct messages
-- `mpim:read` - View group direct messages
-
-### 5. Enable Socket Mode
-
-1. Go to **Socket Mode** in your app settings
-2. Enable Socket Mode
-3. Generate an App-Level Token with `connections:write` scope
-4. Save the token (starts with `xapp-`)
-
-### 6. Create Slash Commands
-
-Go to **Slash Commands** and create:
-- `/contributors` - URL: `https://your-server.com` (or use Socket Mode)
-- `/ghissue` - URL: `https://your-server.com`
-- `/project` - URL: `https://your-server.com`
-- `/repo` - URL: `https://your-server.com`
-
-### 7. Install App to Workspace
-
-1. Go to **Install App**
-2. Click "Install to Workspace"
-3. Authorize the requested permissions
-4. Save the Bot User OAuth Token (starts with `xoxb-`)
-
-### 8. Configure Environment Variables
-
-Create a `.secrets` file in the project root:
-```bash
-cp .secrets.sample .secrets
-```
-
-Edit `.secrets` with your credentials:
-```bash
-SLACK_APP_TOKEN=xapp-your-app-level-token
-SLACK_BOT_TOKEN=xoxb-your-bot-user-oauth-token
-GITHUB_TOKEN=ghp_your-github-personal-access-token
-```
-
-**Getting a GitHub Token:**
-1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
-2. Generate new token with `repo` and `user` scopes
-3. Copy the token to your `.secrets` file
-
-### 9. Run the Bot
-```bash
-poetry run python app.py
-```
-
-You should see:
-```
-⚡️ Bolt app is running!
-```
-
-### 10. Test the Bot
-
-In your Slack workspace, try:
-```
-/contributors
-/project
-/repo python
-```
+For initial setup and local development instructions, see the **[Local Development](#-local-development)** section below.
 
 ## 📚 Slack Commands
 
@@ -318,10 +226,10 @@ This section explains how to run the BLT-Sammich Slack bot locally for developme
 
 - **Node.js & npm** - [Download Node.js](https://nodejs.org/en/download/). This is required to run Wrangler.
 - **Slack workspace** with admin access to create and configure a Slack app.
-- **Github account**
+- **GitHub account**
 with a Personal Access Token (for `/ghissue` and `/contributors` commands)
 - **Python 3.10+** — [Download Python](https://www.python.org/downloads/)
-- **Wrangler** - For dependency management. Install via: `npm install -g wrangler`
+- **Wrangler** - CLI for developing, testing, and deploying Cloudflare Workers. Install via: `npm install -g wrangler`
 
 ### Steps to run locally
 **1.Clone the repository**
@@ -363,7 +271,7 @@ You should see:
 [wrangler:info] Ready on http://127.0.0.1:8787
 ```
 
-The bot uses **Cloudflare Workers** natively, so you can test it locally without a public URL.
+The bot uses **Cloudflare Workers** natively. For local development, `wrangler dev` creates a local server, but to test Slack commands and webhooks, you must expose your local server using a tunnel like **ngrok** or **cloudflared** (see Troubleshooting).
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ This section documents each Slack command with purpose, example usage, and expec
 | `/project [name]` | Find OWASP project info | `/project zap` | BLT-Sammich only |
 | `/repo [tech]` | Find repos by technology | `/repo python` | BLT-Sammich only |
 | `/discover [term]` | Search all OWASP repos | `/discover security` | Main BLT only |
+| `/help [term]` | Show help menu | `/help` | BLT-Sammich only |
+
 
 ## 🧑‍💻 Local Development
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Searches and browses OWASP repositories.
 
 ### Plugins Architecture
 
-BLT-Sammich is built with a modular plugin system:
+BLT-Sammich is built with a modular plugin system designed to run efficently at the edge:
 
 1. **Contributors Plugin** (`src/sammich/plugins/contributors.py`)
    - Fetches GitHub data via REST API
@@ -99,14 +99,14 @@ BLT-Sammich is built with a modular plugin system:
    - Displays activity in formatted tables
 
 2. **Project Plugin** (`src/sammich/plugins/project.py`)
-   - Manages OWASP project database
+   - Manages OWASP project database lookups natively on the edge
    - Handles pagination for large datasets
-   - Interactive Slack components
+   - Returns interactive Slack UI components
 
 3. **Reminder Plugin** (`src/sammich/plugins/reminder.py`)
-   - Schedule messages to channels
    - Parse natural language time expressions
-   - Supports recurring reminders (Note: Currently not integrated in app.py)
+   - Formats scheduled messages for channels
+   - *(Note: Currently being adapted from background tasks to Cloudflare Cron Triggers for the serverless environment)* 
 
 ### Data Files
 
@@ -116,34 +116,29 @@ BLT-Sammich is built with a modular plugin system:
 ## 🏗️ Architecture
 
 ### Tech Stack
-- **Framework:** Slack Bolt for Python
-- **GitHub Integration:** PyGithub library
-- **Environment Management:** python-dotenv
-- **Build System:** Poetry for dependency management
+- **Edge Runtime:** Cloudflare Python Workers (Pyodide) - A zero-dependency, event-driven model that runs Python natively in the V8 engine
+- **Database:** Cloudflare D1 (Serverless SQLite)
+- **GitHub Integration:** Edge compatible REST requests
+- **Deployment & Testing:** Wrangler (`npx wrangler`) 
 
 ### How It Connects to Main BLT
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
-│                   User in Slack                     │
+│                  User in Slack                      │
 └─────────────────┬───────────────────────────────────┘
-                  │
-                  ├─ Standalone Commands ──────────────┐
-                  │  (/contributors, /ghissue,         │
-                  │   /project, /repo)                 │
-                  │                                    │
-                  v                                    v
-         ┌────────────────────┐            ┌──────────────────┐
-         │   BLT-Sammich Bot  │            │   Main BLT Bot   │
-         │  (This Repository) │            │  (/discover)     │
-         └─────────┬──────────┘            └────────┬─────────┘
-                   │                                │
-                   v                                v
-         ┌─────────────────────┐          ┌─────────────────┐
-         │   GitHub API         │          │  OWASP GitHub   │
-         │   OWASP-BLT/Lettuce │          │  Organization   │
-         └─────────────────────┘          └─────────────────┘
-```
+                  │ (Slash Commands via Webhooks)
+                  v
+         ┌────────────────────┐
+         │ Cloudflare Worker  │  <-- Python (Pyodide)
+         │   (BLT-Sammich)    │      Zero-Dependency
+         └─┬────────────────┬─┘      Event-Driven
+           │                │
+           v                v
+  ┌────────────────┐ ┌─────────────────────┐
+  │ Cloudflare D1  │ │     GitHub API      │
+  │ (Local SQLite) │ │ OWASP-BLT/Lettuce   │
+  └────────────────┘ └─────────────────────┘
 
 **Key Connections:**
 - Both bots interact with GitHub APIs independently
@@ -317,26 +312,28 @@ This section documents each Slack command with purpose, example usage, and expec
 
 ## 🧑‍💻 Local Development
 
-This section explains how to run the BLT-Sammich Slack bot locally for development and testing.
+This section explains how to run the BLT-Sammich Slack bot locally for development and testing using the Cloudflare Workers ecosystem.
 
 ### Prerequisites
 
+- **Node.js & npm** - [Download Node.js](https://nodejs.org/en/download/). This is required to run Wrangler.
+- **Slack workspace** with admin access to create and configure a Slack app.
+- **Github account**
+with a Personal Access Token (for `/ghissue` and `/contributors` commands)
 - **Python 3.10+** — [Download Python](https://www.python.org/downloads/)
-- **Poetry** — For dependency management. Install via: `pip install poetry` or [official installer](https://python-poetry.org/docs/#installation)
-- **Slack workspace** with admin access to create and configure a Slack app
-- **GitHub account** with a Personal Access Token (for `/ghissue` and `/contributors` commands)
+- **Wrangler** - For dependency management. Install via: `npm install -g wrangler`
 
-### Steps to Run Locally
-
-**1. Clone the repository**
+### Steps to run locally
+**1.Clone the repository**
 ```bash
 git clone https://github.com/OWASP-BLT/BLT-Sammich.git
 cd BLT-Sammich
 ```
 
-**2. Install dependencies**
+**2. Configure Local Database (D1)**
+Before running the bot, you must initialize the local D1 database schema:
 ```bash
-poetry install
+npx wrangler d1 execute blt-sammich --local --file=migrations/0001_initial.sql
 ```
 
 **3. Configure environment variables**
@@ -357,25 +354,26 @@ GITHUB_TOKEN=ghp_your-github-personal-access-token
 
 **4. Start the bot**
 ```bash
-poetry run python app.py
+npx wrangler dev
 ```
 
 You should see:
-```
-⚡️ Bolt app is running!
+```text
+⎔ Starting local server...
+[wrangler:info] Ready on http://127.0.0.1:8787
 ```
 
-The bot uses **Socket Mode**, so it connects to Slack without needing a public URL. You can run it entirely on your local machine.
+The bot uses **Cloudflare Workers** natively, so you can test it locally without a public URL.
 
 ### Troubleshooting
 
 | Problem | Solution |
 |---------|----------|
-| **`poetry: command not found`** | Install Poetry: `pip install poetry` or use the [official installer](https://python-poetry.org/docs/#installation) |
-| **`ModuleNotFoundError` or import errors** | Run `poetry install` to ensure all dependencies are installed |
+| **`wrangler: command not found`** | Install Wrangler: `npm install -g wrangler` or use `npx wrangler` |
+| **`Resource location: local` Error** | Ensure you've run the `d1 execute` command to create the local database first |
 | **`KeyError` when reading `.secrets`** | Ensure `.secrets` exists and contains all three variables: `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `GITHUB_TOKEN` |
-| **Bot not responding in Slack** | Verify the bot is installed in your workspace (Install App → Install to Workspace). Check that Socket Mode is enabled in your Slack app settings |
-| **`/ghissue` fails with "Failed to create issue"** | Verify your `GITHUB_TOKEN` has `repo` scope. Ensure the token is valid and not expired |
+| **Bot not responding in Slack** | Verify the bot is installed in your workspace. Check that the Request URL in Slack points to your local tunnel (if testing webhooks) |
+| **`/ghissue` fails with "Failed to create issue"** | Verify your `GITHUB_TOKEN` has `repo` scope and the correct owner/repo is set in `.secrets` |
 | **`/contributors` returns "No data available"** | This is normal if there has been no activity in OWASP-BLT/Lettuce in the last 7 days |
 
 For running tests and code formatting, see the [Development](#-development) section.
@@ -418,21 +416,17 @@ For running tests and code formatting, see the [Development](#-development) sect
 ## 🛠️ Development
 
 ### Project Structure
-```
+```text
 BLT-Sammich/
-├── app.py                    # Main bot application
+├── wrangler.toml         # Cloudflare Worker configuration
 ├── src/
-│   ├── settings.py          # Configuration
-│   └── sammich/
-│       └── plugins/         # Bot plugins
-│           ├── contributors.py  # GitHub activity tracking
-│           ├── project.py       # OWASP project lookup
-│           └── reminder.py      # Message scheduling (WIP)
+│   └── worker.py         # Main bot application (Pyodide)
 ├── data/
-│   ├── projects.json        # OWASP projects database
+│   ├── projects.json     # OWASP projects database
 │   └── repos.json          # Technology repository mapping
-├── tests/                   # Unit tests
-└── pyproject.toml          # Poetry dependencies
+├── migrations/           # D1 database schema
+├── public/               # Static assets
+└── tests/                # Unit tests
 ```
 
 ### Running Tests

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -34,6 +34,10 @@ features:
       url: https://sammich.owaspblt.org/slack/commands/
       description: On development
       should_escape: false
+    - command: /help
+      url: https://sammich.owaspblt.org/slack/commands/
+      description: On development
+      should_escape: false
     - command: /installed_apps
       url: https://sammich.owaspblt.org/slack/commands/
       description: List installed apps
@@ -42,6 +46,27 @@ features:
       url: https://sammich.owaspblt.org/slack/commands/
       description: Return the Slack app management URL
       should_escape: false
+    - command: /ghissue
+      url: https://sammich.owaspblt.org/slack/commands/
+      description: Create GitHub issue
+      usage_hint: "[title]"
+      should_escape: false
+    - command: /project
+      url: https://sammich.owaspblt.org/slack/commands/
+      description: Get project info
+      usage_hint: "[name]"
+      should_escape: false
+    - command: /repo
+      url: https://sammich.owaspblt.org/slack/commands/
+      description: Get repo info
+      usage_hint: "[technology]"
+      should_escape: false
+    - command: /contributors
+      url: https://sammich.owaspblt.org/slack/commands/
+      description: Get contributors info
+      usage_hint: "[name]"
+      should_escape: false
+    
 oauth_config:
   redirect_urls:
     - https://sammich.owaspblt.org/oauth/slack/callback

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -64,7 +64,6 @@ features:
     - command: /contributors
       url: https://sammich.owaspblt.org/slack/commands/
       description: Get contributors info
-      usage_hint: "[name]"
       should_escape: false
     
 oauth_config:

--- a/src/worker.py
+++ b/src/worker.py
@@ -672,12 +672,11 @@ async def create_github_issue(title: str, env: Any) -> Tuple[bool, str]:
 def help_response() -> Dict[str, Any]:
     text = (
         "Available commands:\n"
-        "• /help or /blt - Show this menu\n"
-        "• /contributors or /stats - Activity tracking\n"
-        "• /project [name] - Find OWASP project info\n"
-        "• /repo [technology] - Find repos by tech\n"
-        "• /ghissue [title] - Create GitHub issue\n"
-        "• /gsoc - GSoC 2026 ideas"
+        "• /contributors or /stats\n"
+        "• /project [name]\n"
+        "• /repo [technology]\n"
+        "• /ghissue [title]\n"
+        "• /blt-app-url"
     )
     return {
         "response_type": "ephemeral",
@@ -881,7 +880,7 @@ async def command_response(form: Dict[str, str], env: Any) -> Dict[str, Any]:
         return discover_response(command_text)
     if command_name == "/contrib":
         return contrib_response()
-    if command_name in ("/gsoc", "/gsoc25", "/gsoc26"):
+    if command_name == "/gsoc25":
         return {
             "response_type": "ephemeral",
             "text": "Use /discover with a technology or mentor keyword to explore matches.",

--- a/src/worker.py
+++ b/src/worker.py
@@ -672,11 +672,12 @@ async def create_github_issue(title: str, env: Any) -> Tuple[bool, str]:
 def help_response() -> Dict[str, Any]:
     text = (
         "Available commands:\n"
-        "• /contributors or /stats\n"
-        "• /project [name]\n"
-        "• /repo [technology]\n"
-        "• /ghissue [title]\n"
-        "• /blt-app-url"
+        "• /help or /blt - Show this menu\n"
+        "• /contributors or /stats - Activity tracking\n"
+        "• /project [name] - Find OWASP project info\n"
+        "• /repo [technology] - Find repos by tech\n"
+        "• /ghissue [title] - Create GitHub issue\n"
+        "• /gsoc - GSoC 2026 ideas"
     )
     return {
         "response_type": "ephemeral",
@@ -880,7 +881,7 @@ async def command_response(form: Dict[str, str], env: Any) -> Dict[str, Any]:
         return discover_response(command_text)
     if command_name == "/contrib":
         return contrib_response()
-    if command_name == "/gsoc25":
+    if command_name in ("/gsoc", "/gsoc25", "/gsoc26"):
         return {
             "response_type": "ephemeral",
             "text": "Use /discover with a technology or mentor keyword to explore matches.",
@@ -899,7 +900,7 @@ async def command_response(form: Dict[str, str], env: Any) -> Dict[str, Any]:
         }
     if command_name == "/blt-app-url":
         return blt_app_url_response(env)
-    if command_name == "/blt":
+    if command_name in ("/blt", "/help"):
         return help_response()
 
     return {


### PR DESCRIPTION
### 📋 Description
This PR modernizes the bot's interface by adding standard command aliases and synchronizing the Slack App Manifest with the actual codebase. Previously, several powerful commands were "hidden" from users because they were not registered in the manifest.

### 🛠️ Key Changes
* **Standardized Help Alias:** Added `/help` as a standard alias for the existing `/blt` command in `src/worker.py`.
* **App Manifest Synchronization:** Registered 4 previously "hidden" commands in `manifest.yaml` to enable Slack autocomplete discovery:
  * `/help` - (New standard alias)
  * `/ghissue` - Create GitHub issues directly from Slack.
  * `/project` - Browse and search the 800+ OWASP projects database.
  * `/repo` - Search OWASP repositories by technology stack.
* **Documentation Alignment:** Updated the Slash Commands table in `README.md` to reflect the new standardized command list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/help [term]` slash command for quick documentation searches
  * Added `/ghissue [title]`, `/project [name]`, `/repo [technology]`, and `/contributors [name]` slash commands enabling direct GitHub and project information lookups

* **Documentation**
  * Updated README with refreshed architecture diagrams, technology stack documentation, and local development setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->